### PR TITLE
Initial booting screen styling

### DIFF
--- a/lib/proxy-middlewares.js
+++ b/lib/proxy-middlewares.js
@@ -32,8 +32,7 @@ function serveBootPage(req, res, message) {
 	if(res.headersSent) return;
     res.status(202);
     if(isHTML(req)) {
-		var iframe = '<iframe style="width:800px; height:600px" src="' + req.path + '?branch=' + getBranchName(req) + '&log=1"></iframe>';
-		res.send('<head><meta http-equiv="refresh" content="5"></head><body><p>' + message + '</p><br><br>' + iframe + '</body>');
+		res.render('boot', { logUrl: req.path + '?branch=' + getBranchName(req) + '&log=1', message: message } );
 	} else {
 		res.send(message);
 	}
@@ -117,4 +116,3 @@ module.exports = function(proxyManager) {
 		websocket: proxyWebsocket
 	};
 };
-

--- a/lib/server.js
+++ b/lib/server.js
@@ -1,4 +1,5 @@
 var http = require('http');
+var path = require('path');
 var express = require('express');
 var cookieSession = require('cookie-session');
 var WsApp = require('./ws-app');
@@ -16,6 +17,8 @@ module.exports = function(config) {
 	});
 
 	var app = express();
+	app.set('view engine', 'pug');
+	app.set('views', path.join(__dirname, 'views'));
 	app.enable('trust proxy');
 	app.use(sessionMiddleware);
 	app.use(proxyMiddlewares.http);

--- a/lib/views/boot.pug
+++ b/lib/views/boot.pug
@@ -1,0 +1,32 @@
+html
+    head
+        title= message
+        meta(http-equiv="refresh", content="5")
+        style.
+            body {
+                font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen-Sans", "Ubuntu", "Cantarell", "Helvetica Neue", sans-serif;
+                background: #f3f6f8;
+                color: #4f748e;
+                margin: 0;
+            }
+
+            p,
+            .calypsolive-message {
+                height: 21px;
+                overflow: hidden;
+                padding: 16px 9px;
+                margin: 0;
+                background: #2e4453;
+                color: #ffffff;
+            }
+
+            iframe,
+            .calypsolive-log-frame {
+                width: 100%;
+                height: calc( 100% - 57px );
+                border: 0;
+            }
+    body
+        div(class="calypsolive-message")
+            = message
+        iframe(class="calypsolive-log-frame" src= logUrl)

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "http-proxy": "^1.12.0",
     "lodash": "^3.10.1",
     "mkdirp": "^0.5.1",
+    "pug": "^0.1.0",
     "shell-escape": "^0.2.0",
     "ssh-url": "^0.1.5"
   }


### PR DESCRIPTION
I added some initial styling:

![screen shot 2016-06-03 at 17 45 32](https://cloud.githubusercontent.com/assets/4389/15786169/2cbca502-29b3-11e6-8fb6-d749f8056660.png)

A few considerations tho:
1. I wasn't able to test it locally, so it's a bit blind coding.
2. Would be ideal to have a separate CSS file that gets injected. Is that possible or adds too much complexity? With that we could do more fancy stuff.
3. Would be cool if I could have a class reference for the log too. :) 

Here's the CSS non-minified:

```
body {
  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen-Sans", "Ubuntu", "Cantarell", "Helvetica Neue", sans-serif;
  background: #f3f6f8;
  color: #4f748e;
  margin: 0;
}

p,
.calypsolive-message {
  height: 21px;
  overflow: hidden;
  padding: 16px 9px;
  margin: 0;
  background: #2e4453;
  color: #ffffff;
}

iframe,
.calypsolive-log-frame {
  width: 100%;
  height: calc( 100% - 57px );
  border: 0;
}
```
