### PR TITLE
look at bundle.js instead of bundle-development.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Run it with `make run`
 ## TODO
 
 - [x] Display a page while instance is installing.
-- [x] Remove application specific code in `worker.js` (ie `make build` and `require('build/bundle-development.js');`).
+- [x] Remove application specific code in `worker.js` (ie `make build` and `require('build/bundle.js');`).
 - [x] Monitor workers: restart failed workers (or mark them as failing for this commit), shutdown unused workers.
 - [x] Create a Dockerfile.
 - [x] Handle erroring branches.
@@ -40,4 +40,4 @@ Run it with `make run`
 - [ ] Shutdown unused branches after some time.
 - [ ] Add unit tests.
 - [ ] Make a cli and publish it as an npm package.
-- [ ] Find alternatives to `require` to launch the server with the patch on `net.Server.listen` (needed so we can proxy it); have a look at [`node-sandboxed-module`](https://github.com/felixge/node-sandboxed-module). 
+- [ ] Find alternatives to `require` to launch the server with the patch on `net.Server.listen` (needed so we can proxy it); have a look at [`node-sandboxed-module`](https://github.com/felixge/node-sandboxed-module).

--- a/calypso.json
+++ b/calypso.json
@@ -9,7 +9,7 @@
 		"NODE_PATH": "server:client:.",
 		"CALYPSO_LIVE_DEFAULT_CONFIG": "{ \"readyEvent\": \"compiler done\", \"format\": \"html\" }"
 	},
-	"main": "build/bundle-development.js",
+	"main": "build/bundle.js",
 	"scripts": {
 		"postinstall": "make build",
 		"clean": "make distclean"


### PR DESCRIPTION
Landing https://github.com/Automattic/wp-calypso/pull/11352 meant that calypso.live branches broke

This PR seeks to make it work again