### PR TITLE
Update boot screen styling, added link to issues

### DIFF
--- a/lib/views/boot.pug
+++ b/lib/views/boot.pug
@@ -11,6 +11,8 @@ html
 
             p,
             .calypsolive-message {
+                position: fixed;
+                width: 100%;
                 box-sizing: border-box;
                 min-height: 55px;
                 max-height: 80px;
@@ -100,7 +102,7 @@ html
     body
         div(class="calypsolive-message")
             = message
-        div(class="calypsolive-toolbar")
-            a(href="https://github.com/Automattic/calypso-live-branches/issues") Report Issues
+            div(class="calypsolive-toolbar")
+                a(href="https://github.com/Automattic/calypso-live-branches/issues") Report Issues
         div(class="calypsolive-log-frame")
             pre

--- a/lib/views/boot.pug
+++ b/lib/views/boot.pug
@@ -11,19 +11,57 @@ html
 
             p,
             .calypsolive-message {
-                height: 21px;
+                box-sizing: border-box;
+                min-height: 55px;
+                max-height: 80px;
                 overflow: hidden;
-                padding: 16px 9px;
+                padding: 16px 20px;
                 margin: 0;
                 background: #2e4453;
                 color: #ffffff;
+
+                animation: progress-bar-animation 3300ms infinite linear;
+                background-image: linear-gradient( -45deg, #3d596d 28%, #334b5c 28%, #334b5c 72%, #3d596d 72%);
+                background-size: 200px 100%;
+                background-repeat: repeat-x;
+                background-position: 0 50px;
+            }
+
+            .calypsolive-toolbar {
+                position: absolute;
+                top: 12px;
+                right: 4px;
+                box-sizing: border-box;
+                display: flex;
+            }
+            .calypsolive-toolbar a {
+                display: inline-block;
+                border: 1px solid #ffffff;
+                border-radius: 3px;
+                padding: 4px 6px;
+                margin: 0 10px 0 0;
+                font-size: 12px;
+                text-decoration: none;
+                color: #ffffff;
+                background: #2e4453;
+                transition: all 200ms ease-in;
+            }
+            .calypsolive-toolbar a:hover {
+                background: #ffffff;
+                color: #2e4453;
             }
 
             iframe,
             .calypsolive-log-frame {
+                box-sizing: border-box;
                 width: 100%;
-                height: calc( 100% - 57px );
+                height: calc( 100% - 66px );
                 border: 0;
+                padding: 5px 20px;
+            }
+            @keyframes progress-bar-animation {
+                0%   { background-position: 400px 50px; }
+                100% {  }
             }
         script(src="https://code.jquery.com/jquery-1.12.4.min.js", integrity="sha256-ZosEbRLbNQzLpnKIkEdrPv7lOy9C27hHQ+Xp8a4MxAQ=", crossorigin="anonymous")
         script var config = !{JSON.stringify(config).replace(/<\//g, '<\\/')}
@@ -62,6 +100,7 @@ html
     body
         div(class="calypsolive-message")
             = message
+        div(class="calypsolive-toolbar")
+            a(href="https://github.com/Automattic/calypso-live-branches/issues") Report Issues
         div(class="calypsolive-log-frame")
             pre
-


### PR DESCRIPTION
![cap-](https://cloud.githubusercontent.com/assets/4389/24048437/cd0e76ee-0b20-11e7-8df5-9cd73e7b1987.gif)

This PR:

* Updates the header styling to add a simple animation in Calypso style
* Updates the heights so the scrollbar doesn't appear if there's no content
* Updates the height of the message bar so it gets taller if there are longer issues (edge case)
* Added fixed positioning, so now the top bar stays when scrolling
* Added button to link to this repository Issue board 