### PR TITLE
Update vulnerable npm dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,9 +24,9 @@
     "debug": "^2.2.0",
     "express": "^4.13.3",
     "http-proxy": "^1.12.0",
-    "lodash": "^3.10.1",
+    "lodash": "^4.18.1",
     "mkdirp": "^0.5.1",
-    "pug": "^0.1.0",
+    "pug": "^3.0.4",
     "shell-escape": "^0.2.0",
     "ssh-url": "^0.1.5",
     "terminate": "^2.1.0"


### PR DESCRIPTION
## Summary
- Update `lodash` to the patched 4.x line.
- Update `pug` to the patched 3.x line.
- Keep the change manifest-only because this repo ignores `package-lock.json`.

## Validation
- `npm install --ignore-scripts --no-audit`
- `node` smoke check for `lodash.merge`
- `node` smoke check rendering `lib/views/boot.pug` with `pug`
- `node` smoke check loading runtime modules
- `git diff --check`

## Notes
- `npm test` is not currently runnable because the repo declares `mocha` as the test command but does not declare `mocha` as a dependency, and no test files are present.
- `npm audit --audit-level=low` still reports a low transitive `cookie-session` / `on-headers` finding from a temporary install. I left that out of this PR because the current GitHub alerts are for `lodash` and `pug`, and fixing the audit finding requires a separate breaking `cookie-session` update.